### PR TITLE
Persist vote status in local storage

### DIFF
--- a/src/app/voting-proposal/voting-proposal.component.ts
+++ b/src/app/voting-proposal/voting-proposal.component.ts
@@ -153,11 +153,12 @@ export class VotingProposalComponent implements OnInit, OnChanges, OnDestroy {
       this.userHasVoted = true;
       this.userVote = voteChoice;
       
-      // Store vote in session storage for persistence across refreshes
+      // Store vote in local storage so it persists across browser sessions,
+      // deterring multiple votes from the same device
       const sessionKey = `voted_${this.proposal.id}`;
       const voteChoiceKey = `vote_choice_${this.proposal.id}`;
-      sessionStorage.setItem(sessionKey, 'true');
-      sessionStorage.setItem(voteChoiceKey, voteChoice);
+      localStorage.setItem(sessionKey, 'true');
+      localStorage.setItem(voteChoiceKey, voteChoice);
       
       setTimeout(() => this.voteMessage = '', 3000);
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- replace sessionStorage with localStorage for vote tracking
- persist vote choice and status across sessions to deter repeated voting
- document localStorage usage in voting components and services

## Testing
- `npm run lint`
- `CHROME_BIN=/usr/bin/chromium-browser npm test -- --watch=false` *(fails: Chromium snap not installed)*


------
https://chatgpt.com/codex/tasks/task_e_689452e703b48328874f2c62de581741