### PR TITLE
Simplify voter page with dark theme

### DIFF
--- a/src/app/vote-page/vote-page.component.html
+++ b/src/app/vote-page/vote-page.component.html
@@ -1,16 +1,11 @@
-<div class="min-h-screen bg-gray-50 py-8">
+<div class="min-h-screen bg-gray-900 text-gray-100 py-8">
   <div class="container mx-auto px-4 max-w-4xl">
-    <!-- Header -->
-    <div class="text-center mb-8">
-      <h1 class="text-4xl font-bold text-gray-800 mb-2">Votr</h1>
-      <p class="text-xl text-gray-600">Cast Your Vote</p>
-    </div>
 
     <!-- Back Button -->
     <div class="mb-4">
-      <button 
-        (click)="goBack()" 
-        class="text-blue-500 hover:text-blue-600 font-medium flex items-center">
+      <button
+        (click)="goBack()"
+        class="text-blue-400 hover:text-blue-300 font-medium flex items-center">
         <svg class="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
         </svg>
@@ -21,7 +16,7 @@
     <!-- Loading State -->
     <div *ngIf="loading" class="text-center py-12">
       <div class="inline-flex items-center">
-        <svg class="animate-spin -ml-1 mr-3 h-8 w-8 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <svg class="animate-spin -ml-1 mr-3 h-8 w-8 text-blue-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
           <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
         </svg>
@@ -31,7 +26,7 @@
 
     <!-- Error State -->
     <div *ngIf="error && !loading" class="text-center py-12">
-      <div class="text-red-500 text-lg">
+      <div class="text-red-400 text-lg">
         <svg class="mx-auto h-16 w-16 text-red-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
         </svg>

--- a/src/app/voting-proposal/voting-proposal.component.html
+++ b/src/app/voting-proposal/voting-proposal.component.html
@@ -1,10 +1,10 @@
-<div class="max-w-4xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
+<div class="max-w-4xl mx-auto bg-gray-800 text-gray-100 shadow-md rounded-lg p-6 relative">
     <!-- Delete Button -->
     <button 
         *ngIf="canDeleteProposal" 
         (click)="deleteProposal()" 
         [disabled]="isDeleting"
-        class="absolute top-4 right-4 text-gray-500 hover:text-red-600 disabled:text-gray-300 disabled:cursor-not-allowed transition-colors duration-200"
+        class="absolute top-4 right-4 text-gray-400 hover:text-red-400 disabled:text-gray-600 disabled:cursor-not-allowed transition-colors duration-200"
         aria-label="Delete proposal">
         <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
             <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
@@ -12,7 +12,7 @@
     </button>
 
     <div *ngIf="isCreator" class="mb-2">
-      <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+      <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-900 text-blue-100">
         <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
           <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"></path>
         </svg>
@@ -21,19 +21,19 @@
     </div>
 
     <h2 class="text-2xl font-bold mb-4">{{ proposal.title }}</h2>
-    <p class="text-gray-700 mb-6">{{ proposal.description }}</p>
+    <p class="text-gray-300 mb-6">{{ proposal.description }}</p>
 
 
-    <div class="mb-6">
+    <div class="mb-6" *ngIf="isCreator">
         <div class="flex justify-between items-center mb-2">
             <h3 class="font-semibold text-lg">Share Voting Link</h3>
-            
+
         </div>
         <div class="flex items-center gap-2">
-            <input type="text" readonly [value]="voteLink" class="flex-grow p-2 border rounded-lg bg-white" />
-            <button (click)="copyToClipboard(voteLink)" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg">Copy</button>
+            <input type="text" readonly [value]="voteLink" class="flex-grow p-2 border border-gray-600 rounded-lg bg-gray-700 text-gray-100" />
+            <button (click)="copyToClipboard(voteLink)" class="bg-blue-600 hover:bg-blue-500 text-white font-bold py-2 px-4 rounded-lg">Copy</button>
         </div>
-        <p class="text-sm text-gray-500 mt-2">Share this link with team members to vote.</p>
+        <p class="text-sm text-gray-400 mt-2">Share this link with team members to vote.</p>
     </div>
 
     <div class="mb-6">
@@ -41,29 +41,29 @@
         <div class="space-y-4">
             <div>
                 <div class="flex justify-between mb-1">
-                    <span class="font-bold text-green-600">Yes ({{ proposal.votes.yes }})</span>
-                    <span class="text-sm font-medium text-gray-700">{{ yesPercentage }}%</span>
+                    <span class="font-bold text-green-400">Yes ({{ proposal.votes.yes }})</span>
+                    <span class="text-sm font-medium text-gray-300">{{ yesPercentage }}%</span>
                 </div>
-                <div class="w-full bg-gray-200 rounded-full h-4">
+                <div class="w-full bg-gray-700 rounded-full h-4">
                     <div class="bg-green-500 h-4 rounded-full" [style.width.%]="yesPercentage"></div>
                 </div>
             </div>
             <div>
                 <div class="flex justify-between mb-1">
-                    <span class="font-bold text-red-600">No ({{ proposal.votes.no }})</span>
-                    <span class="text-sm font-medium text-gray-700">{{ noPercentage }}%</span>
+                    <span class="font-bold text-red-400">No ({{ proposal.votes.no }})</span>
+                    <span class="text-sm font-medium text-gray-300">{{ noPercentage }}%</span>
                 </div>
-                <div class="w-full bg-gray-200 rounded-full h-4">
+                <div class="w-full bg-gray-700 rounded-full h-4">
                     <div class="bg-red-500 h-4 rounded-full" [style.width.%]="noPercentage"></div>
                 </div>
             </div>
         </div>
-        <p class="text-center mt-4 text-gray-600 font-semibold">Total Votes: {{ totalVotes }}</p>
+        <p class="text-center mt-4 text-gray-400 font-semibold">Total Votes: {{ totalVotes }}</p>
     </div>
 
     <!-- Creator Cannot Vote Message -->
-    <div *ngIf="!showVotingButtons && proposal.status === 'active'" class="mb-6 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-        <p class="text-sm text-yellow-800">
+    <div *ngIf="!showVotingButtons && proposal.status === 'active'" class="mb-6 p-3 bg-yellow-900 border border-yellow-700 rounded-lg">
+        <p class="text-sm text-yellow-100">
             <svg class="inline w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"></path>
             </svg>
@@ -78,7 +78,7 @@
             <button 
                 (click)="vote('yes')" 
                 [disabled]="isVoting"
-                class="bg-green-500 hover:bg-green-600 disabled:bg-gray-400 disabled:cursor-not-allowed text-white font-bold py-2 px-6 rounded-lg transition-colors duration-200">
+                class="bg-green-500 hover:bg-green-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-bold py-2 px-6 rounded-lg transition-colors duration-200">
                 <span *ngIf="!isVoting">Vote Yes</span>
                 <span *ngIf="isVoting" class="inline-flex items-center">
                     <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -91,7 +91,7 @@
             <button 
                 (click)="vote('no')" 
                 [disabled]="isVoting"
-                class="bg-red-500 hover:bg-red-600 disabled:bg-gray-400 disabled:cursor-not-allowed text-white font-bold py-2 px-6 rounded-lg transition-colors duration-200">
+                class="bg-red-500 hover:bg-red-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-bold py-2 px-6 rounded-lg transition-colors duration-200">
                 <span *ngIf="!isVoting">Vote No</span>
                 <span *ngIf="isVoting" class="inline-flex items-center">
                     <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -105,8 +105,8 @@
     </div>
 
     <!-- User Vote Status -->
-    <div *ngIf="hasUserVoted() && voterId" class="mb-6 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-        <p class="text-sm text-blue-800">
+    <div *ngIf="hasUserVoted() && voterId" class="mb-6 p-3 bg-blue-900 border border-blue-700 rounded-lg">
+        <p class="text-sm text-blue-100">
             <strong>You voted:</strong> {{ getUserVote()?.toUpperCase() }}
         </p>
     </div>
@@ -120,15 +120,15 @@
     </div>
 
     <!-- Messages -->
-    <div *ngIf="voteMessage" class="mt-4 p-3 bg-green-100 border border-green-400 text-green-700 rounded-lg">
+    <div *ngIf="voteMessage" class="mt-4 p-3 bg-green-900 border border-green-700 text-green-100 rounded-lg">
         {{ voteMessage }}
     </div>
 
-    <div *ngIf="copyMessage" class="mt-2 p-2 bg-blue-100 border border-blue-400 text-blue-700 rounded-lg text-sm">
+    <div *ngIf="copyMessage" class="mt-2 p-2 bg-blue-900 border border-blue-700 text-blue-100 rounded-lg text-sm">
         {{ copyMessage }}
     </div>
 
-    <div *ngIf="deleteMessage" class="mt-2 p-3 bg-red-100 border border-red-400 text-red-700 rounded-lg">
+    <div *ngIf="deleteMessage" class="mt-2 p-3 bg-red-900 border border-red-700 text-red-100 rounded-lg">
         {{ deleteMessage }}
     </div>
 </div>

--- a/src/app/voting-proposal/voting-proposal.component.ts
+++ b/src/app/voting-proposal/voting-proposal.component.ts
@@ -63,13 +63,13 @@ export class VotingProposalComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   get statusColor(): string {
-    if (!this.proposal) return 'bg-gray-100 text-gray-800';
+    if (!this.proposal) return 'bg-gray-700 text-gray-200';
     switch (this.proposal.status) {
-      case 'active': return 'bg-blue-100 text-blue-800';
-      case 'passed': return 'bg-green-100 text-green-800';
-      case 'failed': return 'bg-red-100 text-red-800';
-      case 'expired': return 'bg-gray-100 text-gray-800';
-      default: return 'bg-gray-100 text-gray-800';
+      case 'active': return 'bg-blue-900 text-blue-100';
+      case 'passed': return 'bg-green-900 text-green-100';
+      case 'failed': return 'bg-red-900 text-red-100';
+      case 'expired': return 'bg-gray-700 text-gray-200';
+      default: return 'bg-gray-700 text-gray-200';
     }
   }
 


### PR DESCRIPTION
## Summary
- Refine voter-facing page with a cleaner layout and dark styling
- Convert voting proposal component to dark theme and hide sharing tools for non-creators
- Adjust status color mapping for dark backgrounds

## Testing
- `CHROME_BIN=/tmp/chrome.sh npm test -- --watch=false` *(fails: Acquiring an exclusive Navigator LockManager lock "lock:sb-fydmqqrdkqmoupqkcahy-auth-token" immediately failed)*

------
https://chatgpt.com/codex/tasks/task_e_6894576d5518832883b456c92e3629e1