### PR TITLE
feat: configure PocketBase URL via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
 
+## PocketBase configuration
+
+Set the `NG_APP_PB_URL` environment variable to the URL of your PocketBase instance. Development builds default to `http://127.0.0.1:8090` when this variable is not provided.
+
 ## Running unit tests
 
 Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
+ [build.environment]
+   NG_APP_PB_URL = "https://pocketbase.example.com"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly NG_APP_PB_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
   pocketbase: {
-    url: 'http://127.0.0.1:8090'
+    url: import.meta.env.NG_APP_PB_URL || 'http://127.0.0.1:8090'
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
   pocketbase: {
-    url: 'http://127.0.0.1:8090'
+    url: import.meta.env.NG_APP_PB_URL as string
   }
 };


### PR DESCRIPTION
## Summary
- load PocketBase URL from NG_APP_PB_URL at build time
- define typings for import.meta.env
- add NG_APP_PB_URL to Netlify build environment
- document NG_APP_PB_URL in README

## Testing
- `npm install`
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68aac3cd2ae0832881c51ee73d2dd063